### PR TITLE
Remove magento modules required by error with php 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,6 @@
     "name": "transbank/webpay-magento2",
     "description": "Plugin oficial de magento2 para Webpay",
     "require": {
-        "magento/module-sales": "101.0.*",
-        "magento/module-quote": "101.0.*",
-        "magento/module-checkout": "100.2.*",
-        "magento/module-payment": "100.2.*",
-        "magento/framework": "101.0.*",
         "transbank/transbank-sdk": "1.5.1"
     },
     "type": "magento2-module",


### PR DESCRIPTION
the magento modules versions (101.0.*) is not compatible with php 7.2 and magento 2.3.1
We removed the modules because this is not necessary for the plugin