### PR TITLE
Prepare for Magento Marketplace release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,6 @@
     },
     "type": "magento2-module",
     "version": "3.2.3",
-    "extra": {
-        "map": [
-            [
-                "*",
-                "Transbank/Webpay"
-            ]
-        ]
-    },
     "archive": {
         "exclude": [
             "/docs",

--- a/docker-magento2.2/Dockerfile
+++ b/docker-magento2.2/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 	libxslt1-dev \
 	apt-utils \
 	gnupg \
-	mysql-client \
+	default-mysql-client \
 	git \
 	nano \
 	wget \

--- a/docker-magento2.3/Dockerfile
+++ b/docker-magento2.3/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 	libxslt1-dev \
 	apt-utils \
 	gnupg \
-	mysql-client \
+	default-mysql-client \
 	git \
 	nano \
 	wget \


### PR DESCRIPTION
- Remove the "extras" key in composer json, as it's deprecated and its
removal is required by Magento to allow technical review
- Change mysql-client to default-mysql-client on Dockerfiles because
the images got updated and mysql-client is no longer in the repos