### PR TITLE
Return stock when order is canceled

### DIFF
--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -88,8 +88,10 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action {
                 } else {
 
                     $this->checkoutSession->setPaymentOk('FAIL');
+                    $order->cancel();
+                    $order->save();
+                    $order->setStatus($orderStatusCanceled);
 
-                    $order->setState($orderStatusCanceled)->setStatus($orderStatusCanceled);
                     $order->addStatusToHistory($order->getStatus(), json_encode($result));
                     $order->save();
 
@@ -126,7 +128,9 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action {
             $this->checkoutSession->restoreQuote();
             $this->messageManager->addError(__($message));
             if ($order != null) {
-                $order->setState($orderStatusCanceled)->setStatus($orderStatusCanceled);
+                $order->cancel();
+                $order->save();
+                $order->setStatus($orderStatusCanceled);
                 $order->addStatusToHistory($order->getStatus(), $message);
                 $order->save();
             }

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -92,7 +92,9 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action {
                 $this->checkoutSession->setTokenWs($response['token_ws']);
                 $this->checkoutSession->setPaymentOk('WAITING');
             } else {
-                $order->setState($orderStatusCanceled)->setStatus($orderStatusCanceled);
+                $order->cancel();
+                $order->save();
+                $order->setStatus($orderStatusCanceled);
                 $this->checkoutSession->setPaymentOk('ERROR');
                 $message = "<h3>Error en pago con Webpay</h3><br>" . json_encode($response);
             }
@@ -108,7 +110,9 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action {
             $this->log->logError($message);
             $response = array('error' => $message);
             if ($order != null) {
-                $order->setState($orderStatusCanceled)->setStatus($orderStatusCanceled);
+                $order->cancel();
+                $order->save();
+                $order->setStatus($orderStatusCanceled);
                 $order->addStatusToHistory($order->getStatus(), $message);
                 $order->save();
             }

--- a/docker-magento2.2/Dockerfile
+++ b/docker-magento2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.1-apache-stretch
 
 # Install System Dependencies
 RUN apt-get update \

--- a/docker-magento2.3/Dockerfile
+++ b/docker-magento2.3/Dockerfile
@@ -1,5 +1,4 @@
-FROM php:7.2-apache
-
+FROM php:7.2-apache-stretch
 # Install System Dependencies
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
when the order is cancel using the `setStatus` the stock is not coming back, to return the stock is necessary call the `$order->cancel();` and save the order. So we call the cancel function before to set the status from the configuration.