### PR TITLE
fix/remove_bootstrap_and_jquery

### DIFF
--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -4,7 +4,5 @@
     <css src="Transbank_Webpay::css/bootstrap.min.css" />
 	<css src="Transbank_Webpay::css/bootstrap-switch.css"/>
   	<css src="Transbank_Webpay::css/tbk.css"/>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" src_type="url"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" src_type="url"></script>
   </head>
 </page>


### PR DESCRIPTION
Remove bootstrap and jquery

These libraries conflict with their peers in magento so it is necessary to remove
them from the plugin.