### PR TITLE
fix/change-message-transaction-canceled

### DIFF
--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -53,6 +53,10 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action {
 
             $tokenWs = isset($_POST['token_ws']) ? $_POST['token_ws'] : null;
 
+            if(is_null($tokenWs) && isset($_POST['TBK_TOKEN'])){
+                throw new \Exception('Transacción cancelada');
+            }
+            
             if($tokenWs != $this->checkoutSession->getTokenWs()) {
                 throw new \Exception('Token inválido');
             }


### PR DESCRIPTION
Change the message when canceling the transaction

When the transaction is canceled, the name of the parameter that contains the
token changes so that when validated it generates an "Invalid Token" error
message which is not the expected message.

Related to issue #63