### PR TITLE
Fix order status handling

### DIFF
--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -274,7 +274,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
         $this->log->logError($message);
         $this->checkoutSession->restoreQuote();
         $this->messageManager->addError(__($message));
-        if ($order != null && $order->getStatus() != Order::STATE_PROCESSING) {
+        if ($order != null && $order->getState() != Order::STATE_PROCESSING) {
             $order->cancel();
             $order->save();
             $order->setStatus($orderStatusCanceled);

--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -21,6 +21,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
         "S2" => "2 cuotas sin interés",
         "NC" => "N cuotas sin interés",
     ];
+    protected $configProvider;
     
     public function __construct(
         \Magento\Framework\App\Action\Context $context, \Magento\Checkout\Model\Cart $cart,
@@ -49,7 +50,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
     public function execute()
     {
         $config = $this->configProvider->getPluginConfig();
-        $orderStatusCanceled = $config['error_pay'];
+        $orderStatusCanceled = $this->configProvider->getOrderErrorStatus();
         $transactionResult = [];
         try {
             $tokenWs = isset($_POST['token_ws']) ? $_POST['token_ws'] : null;
@@ -82,7 +83,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
                     $payment->setTransactionId($authorizationCode);
                     $payment->setAdditionalInformation([\Magento\Sales\Model\Order\Payment\Transaction::RAW_DETAILS => (array)$transactionResult]);
                     
-                    $orderStatus = $config['sucefully_pay'];
+                    $orderStatus = $this->configProvider->getOrderSuccessStatus();
                     $order->setState($orderStatus)->setStatus($orderStatus);
                     $order->addStatusToHistory($order->getStatus(), json_encode($transactionResult));
                     $order->save();

--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -274,7 +274,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
         $this->log->logError($message);
         $this->checkoutSession->restoreQuote();
         $this->messageManager->addError(__($message));
-        if ($order != null) {
+        if ($order != null && $order->getStatus() != Order::STATE_PROCESSING) {
             $order->cancel();
             $order->save();
             $order->setStatus($orderStatusCanceled);

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -151,7 +151,7 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
             $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
             
             return $objectManager->create('\Magento\Sales\Model\Order')->load($orderId);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return null;
         }
     }

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -74,8 +74,6 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
                 $this->setQuoteData($quote, $guestEmail);
             }
             
-            $quoteData = $quote->getData();
-            
             $quote->getPayment()->importData(['method' => Webpay::CODE]);
             $quote->collectTotals()->save();
             $order = $tmpOrder;

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -106,6 +106,7 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
     
             if (isset($response['token_ws'])) {
                 $webpayOrderData = $this->saveWebpayData($response['token_ws'], WebpayOrderData::PAYMENT_STATUS_WATING, $orderId, $quoteId);
+                $order->setStatus($orderStatusPendingPayment);
             } else {
                 $webpayOrderData = $this->saveWebpayData('', WebpayOrderData::PAYMENT_STATUS_ERROR, $orderId, $quoteId);
                 $order->cancel();

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -13,7 +13,8 @@ use Transbank\Webpay\Model\WebpayOrderData;
  */
 class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
 {
-    
+    protected $configProvider;
+
     /**
      * CreateWebpayM22 constructor.
      *
@@ -53,17 +54,16 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        
         $response = null;
         $order = null;
         $config = $this->configProvider->getPluginConfig();
-        $orderStatusCanceled = $config['error_pay'];
+        $orderStatusCanceled = $this->configProvider->getOrderErrorStatus();
+        $orderStatusPendingPayment = $this->configProvider->getOrderPendingStatus();
+
         try {
-            
             $guestEmail = isset($_GET['guestEmail']) ? $_GET['guestEmail'] : null;
             
             $config = $this->configProvider->getPluginConfig();
-            $orderStatusPendingPayment = $config['order_status'];
             
             $tmpOrder = $this->getOrder();
             $this->checkoutSession->restoreQuote();

--- a/Model/Config/ConfigProvider.php
+++ b/Model/Config/ConfigProvider.php
@@ -3,6 +3,7 @@
 namespace Transbank\Webpay\Model\Config;
 
 class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface {
+    const CONFIG_ROUTE = 'payment/transbank_webpay/security_parameters/';
 
     public function __construct(\Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface) {
 
@@ -18,20 +19,31 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface 
     }
 
     public function getPluginConfig() {
-        $conf = 'payment/transbank_webpay/security_parameters/';
         $config = array(
-			'MODO' => $this->scopeConfigInterface->getValue($conf.'environment'),
-			'PRIVATE_KEY' => $this->scopeConfigInterface->getValue($conf.'private_key'),
-			'PUBLIC_CERT' => $this->scopeConfigInterface->getValue($conf.'public_cert'),
-			'WEBPAY_CERT' => $this->scopeConfigInterface->getValue($conf.'webpay_cert'),
-            'COMMERCE_CODE' => $this->scopeConfigInterface->getValue($conf.'commerce_code'),
+			'MODO' => $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'environment'),
+			'PRIVATE_KEY' => $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'private_key'),
+			'PUBLIC_CERT' => $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'public_cert'),
+			'WEBPAY_CERT' => $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'webpay_cert'),
+            'COMMERCE_CODE' => $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'commerce_code'),
 			'URL_RETURN' => 'checkout/transaction/commitwebpay',
 			'URL_FINAL' => 'checkout/transaction/commitwebpay',
             'ECOMMERCE' => 'magento',
-            'order_status' => $this->scopeConfigInterface->getValue($conf.'order_status'),
-            'sucefully_pay' => $this->scopeConfigInterface->getValue($conf.'sucefully_pay'),
-            'error_pay' => $this->scopeConfigInterface->getValue($conf.'error_pay')
+            'order_status' => $this->getOrderPendingStatus(),
+            'sucefully_pay' => $this->getOrderSuccessStatus(),
+            'error_pay' => $this->getOrderErrorStatus(),
         );
         return $config;
+    }
+
+    public function getOrderPendingStatus() {
+        return $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'order_status');
+    }
+
+    public function getOrderSuccessStatus() {
+        return $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'sucefully_pay');
+    }
+
+    public function getOrderErrorStatus() {
+        return $this->scopeConfigInterface->getValue(self::CONFIG_ROUTE.'error_pay');
     }
 }


### PR DESCRIPTION
The main purpose of this fix is to actually use the "_Estado de Nueva Orden_" defined by the admin in the module config. Previously, Magento's default status was used (`pending`) and there was no way to use the value from the config.

Also, I did some refactoring regarding status to make the code more readable and added a double status check before cancelling an order (this prevents a cancellation to happen if multiple requests from Trabsbank are received when the order is already paid).